### PR TITLE
fix(gex): remove legacy exposure aliases

### DIFF
--- a/data-pipeline.py
+++ b/data-pipeline.py
@@ -88,7 +88,7 @@ from backend.src.api.trading import router as trading_router  # noqa: E402
 
 LOGGER = logging.getLogger("data_pipeline")
 SNAPSHOT_VIEW_KEY_PREFIX = "gex:snapshot:view:"
-GEX_NET_GEX_TS_PREFIX = "ts:gex:net_gex:"
+GEX_SUM_GEX_VOL_TS_PREFIX = "ts:gex:sum_gex_vol:"
 NOISY_STREAM_LOGGERS = [
     "tastytrade",
     "tastytrade.session",
@@ -2189,7 +2189,7 @@ async def gex_monitor_websocket(websocket: WebSocket, symbol: str = "NQ_NDX") ->
 
     GEX_FIELDS = (
         "symbol", "timestamp", "spot", "zero_gamma",
-        "net_gex", "net_gex_oi", "sum_gex_vol", "sum_gex_oi",
+        "sum_gex_vol", "sum_gex_oi",
         "major_pos_vol", "major_pos_oi", "major_pos_vol_gamma",
         "major_neg_vol", "major_neg_oi", "major_neg_vol_gamma",
         "delta_risk_reversal", "max_priors", "maxchange",
@@ -2199,7 +2199,7 @@ async def gex_monitor_websocket(websocket: WebSocket, symbol: str = "NQ_NDX") ->
         "neg_can2_strike", "neg_can2_value", "neg_can2_pct",
     )
 
-    # Map primary symbol to a secondary symbol whose net_gex we display
+    # Map primary symbol to a secondary symbol whose sum_gex_vol we display
     CROSS_GEX_MAP = {"NQ_NDX": "SPX", "SPX": "NQ_NDX"}
 
     def _extract(payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -2234,7 +2234,7 @@ async def gex_monitor_websocket(websocket: WebSocket, symbol: str = "NQ_NDX") ->
                 _cache_gex_snapshot_view(redis_conn, normalized, enriched)
             except Exception:
                 pass
-        # Cross-symbol net GEX (e.g. ES_SPX net_gex when viewing NQ_NDX)
+        # Cross-symbol sum GEX vol (e.g. ES_SPX when viewing NQ_NDX)
         cross_sym = CROSS_GEX_MAP.get(normalized)
         if cross_sym:
             try:
@@ -2243,7 +2243,7 @@ async def gex_monitor_websocket(websocket: WebSocket, symbol: str = "NQ_NDX") ->
                 if cross_raw:
                     cross_snap = json.loads(cross_raw if isinstance(cross_raw, str) else cross_raw.decode("utf-8"))
                     out["cross_symbol"] = cross_sym
-                    out["cross_net_gex"] = cross_snap.get("net_gex")
+                    out["cross_sum_gex_vol"] = cross_snap.get("sum_gex_vol")
             except Exception:
                 pass
         return out
@@ -2605,8 +2605,8 @@ def _get_redis_client():
 
 
 def _get_latest_gex_delta(redis_conn, symbol: str) -> Optional[float]:
-    """Return the rolling 15s average net GEX delta from RedisTimeSeries, if available."""
-    key = f"{GEX_NET_GEX_TS_PREFIX}{(symbol or '').upper()}"
+    """Return the rolling 15s average sum GEX vol delta from RedisTimeSeries, if available."""
+    key = f"{GEX_SUM_GEX_VOL_TS_PREFIX}{(symbol or '').upper()}"
     try:
         rows = redis_conn.execute_command("TS.REVRANGE", key, "+", "-", "COUNT", 100)
     except Exception:

--- a/discord-bot/bot/trade_bot.py
+++ b/discord-bot/bot/trade_bot.py
@@ -291,12 +291,13 @@ class TradeBot(commands.Bot):
                                 return
                     except Exception:
                         pass
-                data = await self.get_gex_data(symbol)
+                data, failure_reason = await self.get_gex_data(symbol)
                 if data:
                     formatter = self.format_gex if show_full else self.format_gex_small
                     await ctx.send(formatter(data))
                 else:
-                    await ctx.send("GEX data not available")
+                    suffix = f": {failure_reason}" if failure_reason else ""
+                    await ctx.send(f"GEX data not available{suffix}")
 
             async def _status_cmd(ctx):
                 if not await self._ensure_status_channel_access(ctx):
@@ -1835,7 +1836,9 @@ class TradeBot(commands.Bot):
             "call_wall", data.get("major_pos_vol"), now
         )
         mapping["put_wall"] = tracker.update("put_wall", data.get("major_neg_vol"), now)
-        mapping["net_gex"] = tracker.update("net_gex", data.get("net_gex"), now)
+        mapping["sum_gex_vol"] = tracker.update(
+            "sum_gex_vol", data.get("sum_gex_vol"), now
+        )
         mapping["scaled_gamma"] = tracker.update(
             "scaled_gamma", data.get("sum_gex_oi"), now
         )
@@ -1851,14 +1854,15 @@ class TradeBot(commands.Bot):
     async def gex(self, ctx, *args):
         """Get GEX snapshot for a symbol. Uses DuckDB first then GEXBot API fallback."""
         symbol, show_full = self._resolve_gex_request(args)
-        data = await self.get_gex_data(symbol)
+        data, failure_reason = await self.get_gex_data(symbol)
         if data:
             response = (
                 self.format_gex(data) if show_full else self.format_gex_short(data)
             )
             await ctx.send(response)
         else:
-            await ctx.send("GEX data not available")
+            suffix = f": {failure_reason}" if failure_reason else ""
+            await ctx.send(f"GEX data not available{suffix}")
 
     async def status(self, ctx):
         try:
@@ -1909,6 +1913,7 @@ class TradeBot(commands.Bot):
         ticker = self.ticker_aliases.get(display_symbol, display_symbol)
         # No transient cache key: use canonical snapshot key only
         snapshot_key = f"{self.redis_snapshot_prefix}{ticker.upper()}"
+        failure_reasons: List[str] = []
 
         # Prefer the canonical snapshot key (written by poller/pipeline)
         try:
@@ -1934,9 +1939,14 @@ class TradeBot(commands.Bot):
                             300,
                             json.dumps(normalized, default=str),
                         )
-                        return normalized
+                        return normalized, None
+                    failure_reasons.append(
+                        f"Redis snapshot at {snapshot_key} is older than 30 seconds"
+                    )
+            else:
+                failure_reasons.append(f"Redis snapshot miss at {snapshot_key}")
         except Exception as e:
-            print(f"Redis snapshot check failed: {e}")
+            failure_reasons.append(f"Redis snapshot lookup failed: {e}")
 
         # NOTE: transient cache key removed; only canonical snapshot key is used for feed and lookups
 
@@ -1965,7 +1975,7 @@ class TradeBot(commands.Bot):
                             300,
                             json.dumps(normalized, default=str),
                         )
-                        return normalized
+                        return normalized, None
                     if age <= 30:
                         normalized["_freshness"] = "stale"
                         normalized["_source"] = "redis-snapshot"
@@ -1980,18 +1990,25 @@ class TradeBot(commands.Bot):
                                 ticker, snapshot_key, display_symbol
                             )
                         )
-                        return normalized
+                        return normalized, None
                     normalized["_freshness"] = "incomplete"
                     normalized["_source"] = "redis-snapshot"
+                    failure_reasons.append(
+                        f"Redis snapshot at {snapshot_key} is older than 30 seconds"
+                    )
                     await asyncio.to_thread(
                         self.redis_client.setex,
                         snapshot_key,
                         300,
                         json.dumps(normalized, default=str),
                     )
-                    return normalized
+                    return normalized, None
+            else:
+                failure_reasons.append(f"Canonical Redis snapshot miss at {snapshot_key}")
         except Exception as e:
-            print(f"Snapshot redis check failed for {snapshot_key}: {e}")
+            failure_reasons.append(
+                f"Canonical Redis snapshot lookup failed for {snapshot_key}: {e}"
+            )
 
         # 2) Query local DuckDB snapshot before resorting to live API
         try:
@@ -2000,7 +2017,7 @@ class TradeBot(commands.Bot):
                 import duckdb
 
                 q = f"""
-                SELECT timestamp, ticker, spot_price, zero_gamma, net_gex,
+                SELECT timestamp, ticker, spot_price, zero_gamma,
                        sum_gex_vol, delta_risk_reversal, min_dte, sec_min_dte,
                        major_pos_vol, major_neg_vol, major_pos_oi, major_neg_oi,
                        sum_gex_oi, max_priors,
@@ -2047,7 +2064,6 @@ class TradeBot(commands.Bot):
                     "ticker",
                     "spot_price",
                     "zero_gamma",
-                    "net_gex",
                     "sum_gex_vol",
                     "delta_risk_reversal",
                     "min_dte",
@@ -2121,14 +2137,18 @@ class TradeBot(commands.Bot):
                     300,
                     json.dumps(data, default=str),
                 )
-                return data
+                return data, None
+            failure_reasons.append(f"DuckDB row miss for {ticker}")
         except Exception as e:
-            print(f"DuckDB query failed: {e}")
+            failure_reasons.append(f"DuckDB lookup failed: {e}")
 
         # 3) Finally, poll the live API as a last resort
         try:
             if not self.gex_api_enabled:
-                return None
+                failure_reasons.append(
+                    "Live GEXBot API fallback is disabled (GEX_API_ENABLED=false)"
+                )
+                return None, "; ".join(failure_reasons)
             api_data = await self._poll_gexbot_api(ticker)
             if api_data:
                 api_data["_freshness"] = "current"
@@ -2143,11 +2163,12 @@ class TradeBot(commands.Bot):
                     )
                 except Exception:
                     pass
-                return api_data
+                return api_data, None
+            failure_reasons.append(f"Live GEXBot API returned no data for {ticker}")
         except Exception as e:
-            print(f"API fetch failed: {e}")
+            failure_reasons.append(f"Live GEXBot API lookup failed: {e}")
 
-        return None
+        return None, "; ".join(failure_reasons) if failure_reasons else None
 
     async def _poll_gexbot_api(self, ticker: str):
         """Poll the zero endpoint only, limiting outbound requests."""
@@ -2174,7 +2195,7 @@ class TradeBot(commands.Bot):
             "ticker": ticker,
             "spot_price": None,
             "zero_gamma": None,
-            "net_gex": None,
+            "sum_gex_vol": None,
             "major_pos_vol": None,
             "major_neg_vol": None,
             "major_pos_oi": None,
@@ -2193,18 +2214,20 @@ class TradeBot(commands.Bot):
             data["zero_gamma"] = (
                 z.get("zero_gamma") or z.get("zero_gamma_vol") or data["zero_gamma"]
             )
-            data["net_gex"] = z.get("net_gex") or z.get("sum_gex") or data["net_gex"]
+            data["sum_gex_vol"] = z.get("sum_gex_vol") or z.get("sum_gex")
             data["major_pos_vol"] = z.get("major_pos_vol") or data["major_pos_vol"]
             data["major_neg_vol"] = z.get("major_neg_vol") or data["major_neg_vol"]
             data["major_pos_oi"] = z.get("major_pos_oi") or data["major_pos_oi"]
             data["major_neg_oi"] = z.get("major_neg_oi") or data["major_neg_oi"]
-            data["sum_gex_oi"] = (
-                z.get("sum_gex_oi") or z.get("net_gex_oi") or data["sum_gex_oi"]
-            )
+            data["sum_gex_oi"] = z.get("sum_gex_oi") or data["sum_gex_oi"]
             strikes = z.get("strikes")
             if strikes:
                 data["strikes"] = strikes
             data.update(self._extract_compact_wall_fields(z))
+            wall_ladders = self._build_compact_wall_ladders(data)
+            if wall_ladders:
+                data["_wall_ladders"] = wall_ladders
+                self._flatten_wall_ladder_fields(data, wall_ladders)
 
         return data
 
@@ -2343,12 +2366,12 @@ class TradeBot(commands.Bot):
             "zero_gamma": get_first(
                 payload.get("zero_gamma"), payload.get("zero_gamma_vol")
             ),
-            "net_gex": payload.get("net_gex") or payload.get("sum_gex"),
             "major_pos_vol": payload.get("major_pos_vol"),
             "major_neg_vol": payload.get("major_neg_vol"),
             "major_pos_oi": payload.get("major_pos_oi"),
             "major_neg_oi": payload.get("major_neg_oi"),
-            "sum_gex_oi": payload.get("sum_gex_oi") or payload.get("net_gex_oi"),
+            "sum_gex_vol": payload.get("sum_gex_vol") or payload.get("sum_gex"),
+            "sum_gex_oi": payload.get("sum_gex_oi"),
             "max_priors": self._extract_max_priors(payload),
             "maxchange": payload.get("maxchange")
             if isinstance(payload.get("maxchange"), dict)
@@ -2467,11 +2490,9 @@ class TradeBot(commands.Bot):
 
     @staticmethod
     def _build_compact_wall_ladders(data: dict) -> Optional[dict]:
-        compact = TradeBot._extract_compact_wall_fields(data)
-        if not compact:
-            return None
-
         summary: Dict[str, dict] = {}
+        compact = TradeBot._extract_compact_wall_fields(data)
+        strikes = TradeBot._normalize_strike_entries(data.get("strikes"))
         for side, prefix in (("call", "pos"), ("put", "neg")):
             major_key = "major_pos_vol" if side == "call" else "major_neg_vol"
             entries = []
@@ -2488,6 +2509,13 @@ class TradeBot(commands.Bot):
                         "pct_vs_major": pct,
                     }
                 )
+            if not entries:
+                fallback_summary = TradeBot._summarize_wall_ladder(
+                    data.get(major_key), strikes, prefer_positive=(side == "call")
+                )
+                if fallback_summary:
+                    summary[side] = fallback_summary
+                    continue
             if entries:
                 summary[side] = {
                     "major_strike": data.get(major_key),
@@ -3748,10 +3776,10 @@ class TradeBot(commands.Bot):
             call_wall_line,
             put_wall_line,
             fmt_pair(
-                "net gex",
-                data.get("net_gex"),
+                "sum gex vol",
+                data.get("sum_gex_vol"),
                 data.get("sum_gex_oi"),
-                volume_color=color_for_value(data.get("net_gex")),
+                volume_color=color_for_value(data.get("sum_gex_vol")),
                 oi_color=color_for_value(data.get("sum_gex_oi")),
                 formatter=fmt_net_gex,
             ),
@@ -3899,9 +3927,11 @@ class TradeBot(commands.Bot):
             + "  "
         )
 
-        net_color_code = ansi.get(color_for_value(data.get("net_gex")))
-        net_value = colorize(net_color_code, fmt_net_gex(data.get("net_gex")))
-        net_line = f"{'net gex':<{classic_label_width}}{net_value}"
+        net_color_code = ansi.get(color_for_value(data.get("sum_gex_vol")))
+        net_value = colorize(
+            net_color_code, fmt_net_gex(data.get("sum_gex_vol"))
+        )
+        net_line = f"{'sum gex vol':<{classic_label_width}}{net_value}"
 
         current_entry = self._extract_current_maxchange_entry(data)
 
@@ -4040,8 +4070,10 @@ class TradeBot(commands.Bot):
             ),
         )
 
-        net_color_code = ansi.get(color_for_value(data.get("net_gex")))
-        net_value = colorize(net_color_code, fmt_net_gex(data.get("net_gex")))
+        net_color_code = ansi.get(color_for_value(data.get("sum_gex_vol")))
+        net_value = colorize(
+            net_color_code, fmt_net_gex(data.get("sum_gex_vol"))
+        )
 
         sum_gex_oi_value = fmt_price(data.get("sum_gex_oi"))
         sum_gex_oi_color = ansi.get(color_for_value(data.get("sum_gex_oi")))
@@ -4260,14 +4292,14 @@ class TradeBot(commands.Bot):
                 return "N/ABn"
             return f"{(abs(delta) / 1000):.4f}Bn"
 
-        net_snap = snapshot("net_gex")
+        net_snap = snapshot("sum_gex_vol")
         net_value = colorize(
-            ansi.get(color_for_value(data.get("net_gex"))),
-            fmt_net_gex(data.get("net_gex")),
+            ansi.get(color_for_value(data.get("sum_gex_vol"))),
+            fmt_net_gex(data.get("sum_gex_vol")),
         )
         net_change_color = ansi.get(color_for_delta(net_snap.delta))
         net_change_txt = colorize(net_change_color, fmt_net_change(net_snap.delta))
-        lines.append(f"net gex           {net_value:<10} Δ{net_change_txt}")
+        lines.append(f"sum gex vol       {net_value:<10} Δ{net_change_txt}")
 
         scaled_snap = snapshot("scaled_gamma")
         scaled_value = fmt_net_gex(data.get("sum_gex_oi"))

--- a/src/services/gex_duckdb_writer.py
+++ b/src/services/gex_duckdb_writer.py
@@ -179,10 +179,42 @@ class GEXDuckDBWriter:
             snapshot_rows.append(row)
         if not snapshot_rows:
             return
+        snapshot_columns = (
+            "timestamp",
+            "ticker",
+            "spot_price",
+            "zero_gamma",
+            "net_gex",
+            "min_dte",
+            "sec_min_dte",
+            "major_pos_vol",
+            "major_pos_oi",
+            "major_pos_vol_gamma",
+            "major_neg_vol",
+            "major_neg_oi",
+            "major_neg_vol_gamma",
+            "sum_gex_vol",
+            "sum_gex_oi",
+            "delta_risk_reversal",
+            "max_priors",
+            "pos_can1_strike",
+            "pos_can1_value",
+            "pos_can1_pct",
+            "pos_can2_strike",
+            "pos_can2_value",
+            "pos_can2_pct",
+            "neg_can1_strike",
+            "neg_can1_value",
+            "neg_can1_pct",
+            "neg_can2_strike",
+            "neg_can2_value",
+            "neg_can2_pct",
+        )
+        placeholders = ", ".join(["?"] * len(snapshot_columns))
         with duckdb.connect(str(db_path)) as conn:
             self._ensure_schema(conn)
             conn.executemany(
-                """
+                f"""
                 INSERT INTO gex_snapshots (
                     timestamp,
                     ticker,
@@ -213,7 +245,7 @@ class GEXDuckDBWriter:
                     neg_can2_strike,
                     neg_can2_value,
                     neg_can2_pct
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES ({placeholders})
                 """,
                 snapshot_rows,
             )

--- a/src/services/gexbot_poller.py
+++ b/src/services/gexbot_poller.py
@@ -427,24 +427,16 @@ class GEXBotPoller:
                 float(timestamp), tz=timezone.utc
             ).isoformat()
 
-        net_gex = _first(
-            zero_payload.get("net_gex"),
-            zero_payload.get("net_gex_vol"),
+        sum_gex_vol = _first(
             zero_payload.get("sum_gex_vol"),
+            zero_payload.get("sum_gex"),
         )
-        net_gex_oi = _first(
-            zero_payload.get("net_gex_oi"),
-            zero_payload.get("sum_gex_oi"),
-        )
-
         snapshot = {
             "symbol": symbol.upper(),
             "timestamp": timestamp,
             "spot": _to_float(_first(zero_payload.get("spot"))),
             "zero_gamma": _to_float(_first(zero_payload.get("zero_gamma"))),
-            "net_gex": _to_float(net_gex),
-            "net_gex_oi": _to_float(net_gex_oi),
-            "sum_gex_vol": _to_float(zero_payload.get("sum_gex_vol")),
+            "sum_gex_vol": _to_float(sum_gex_vol),
             "sum_gex_oi": _to_float(zero_payload.get("sum_gex_oi")),
             "major_pos_vol": _to_float(_first(zero_payload.get("major_pos_vol"))),
             "major_neg_vol": _to_float(_first(zero_payload.get("major_neg_vol"))),
@@ -452,7 +444,6 @@ class GEXBotPoller:
             "major_neg_oi": _to_float(_first(zero_payload.get("major_neg_oi"))),
             "delta_risk_reversal": _to_float(_first(zero_payload.get("delta_risk_reversal"))),
         }
-        snapshot["net_gex_vol"] = snapshot["net_gex"]
         snapshot["major_pos"] = snapshot["major_pos_vol"]
         snapshot["major_neg"] = snapshot["major_neg_vol"]
         snapshot["ticker"] = snapshot["symbol"]
@@ -472,8 +463,6 @@ class GEXBotPoller:
         metrics = {
             "spot": snapshot.get("spot"),
             "zero_gamma": snapshot.get("zero_gamma"),
-            "net_gex": snapshot.get("net_gex"),
-            "net_gex_oi": snapshot.get("net_gex_oi"),
             "sum_gex_vol": snapshot.get("sum_gex_vol"),
             "sum_gex_oi": snapshot.get("sum_gex_oi"),
             "major_pos_vol": snapshot.get("major_pos_vol"),
@@ -557,20 +546,20 @@ class GEXBotPoller:
             return
         key = f"{SNAPSHOT_KEY_PREFIX}{symbol.upper()}"
         
-        net_gex = snapshot.get("net_gex")
+        sum_gex_vol = snapshot.get("sum_gex_vol")
         major_pos_vol = snapshot.get("major_pos_vol") or 0
         major_neg_vol = snapshot.get("major_neg_vol") or 0
 
-        if net_gex is None and major_pos_vol == 0 and major_neg_vol == 0:
+        if sum_gex_vol is None and major_pos_vol == 0 and major_neg_vol == 0:
             if self.redis:
                 try:
                     existing = self.redis.client.get(key)
                     if existing:
                         existing_data = json.loads(existing)
-                        existing_net_gex = existing_data.get("net_gex")
+                        existing_sum_gex_vol = existing_data.get("sum_gex_vol")
                         existing_pos_vol = existing_data.get("major_pos_vol") or 0
 
-                        if existing_net_gex is not None or existing_pos_vol > 0:
+                        if existing_sum_gex_vol is not None or existing_pos_vol > 0:
                             LOGGER.info(
                                 "Preserving existing snapshot for %s (has volume data)",
                                 symbol

--- a/src/services/tests/test_gexbot_snapshot_timestamps.py
+++ b/src/services/tests/test_gexbot_snapshot_timestamps.py
@@ -76,7 +76,7 @@ async def test_snapshot_timestamps_increment():
             "timestamp": ts_val,
             "spot": 100.0,
             "zero_gamma": 0.1,
-            "net_gex": 50,
+            "sum_gex_vol": 50,
             "major_pos_vol": 10,
             "major_neg_vol": -5,
             "major_pos_oi": 1,
@@ -94,14 +94,14 @@ async def test_snapshot_timestamps_increment():
 
     # Collect snapshot keys and timestamps
     pairs = [(rec[0], rec[1]) for rec in ts.samples if rec[0].startswith("ts:gex:")]
-    # Filter to 'net_gex' metric as a sample per symbol
-    net_gex_pairs = [p for p in pairs if ":net_gex:" in p[0]]
-    assert len(net_gex_pairs) >= 2
+    # Filter to 'sum_gex_vol' metric as a sample per symbol
+    sum_gex_vol_pairs = [p for p in pairs if ":sum_gex_vol:" in p[0]]
+    assert len(sum_gex_vol_pairs) >= 2
     # Each symbol's timestamps must be strictly increasing (the per-symbol guarantee).
     # Global ordering across symbols is not guaranteed because symbols are fetched concurrently.
     by_symbol: dict = {}
-    for key, ts_ms in net_gex_pairs:
-        sym = key.split(":")[3]  # "ts:gex:net_gex:SPX" → "SPX"
+    for key, ts_ms in sum_gex_vol_pairs:
+        sym = key.split(":")[3]  # "ts:gex:sum_gex_vol:SPX" → "SPX"
         by_symbol.setdefault(sym, []).append(ts_ms)
     for sym, tss in by_symbol.items():
         assert all(tss[i] < tss[i + 1] for i in range(len(tss) - 1)), (
@@ -129,7 +129,7 @@ async def test_static_snapshot_timestamps_bumped():
             "timestamp": static_ts,
             "spot": 100.0,
             "zero_gamma": 0.1,
-            "net_gex": 50,
+            "sum_gex_vol": 50,
             "major_pos_vol": 10,
             "major_neg_vol": -5,
             "major_pos_oi": 1,
@@ -146,10 +146,10 @@ async def test_static_snapshot_timestamps_bumped():
 
     # Ensure duplicate timestamps are bumped so they still publish in order
     pairs = [(rec[0], rec[1]) for rec in ts.samples if rec[0].startswith("ts:gex:")]
-    net_gex_pairs = [p for p in pairs if ":net_gex:" in p[0]]
-    assert len(net_gex_pairs) >= 2
+    sum_gex_vol_pairs = [p for p in pairs if ":sum_gex_vol:" in p[0]]
+    assert len(sum_gex_vol_pairs) >= 2
     by_symbol = {}
-    for key, ts_ms in net_gex_pairs:
+    for key, ts_ms in sum_gex_vol_pairs:
         parts = key.split(":")
         sym = parts[3] if len(parts) >= 4 else "UNKNOWN"
         by_symbol.setdefault(sym, []).append(ts_ms)
@@ -175,7 +175,7 @@ async def test_snapshot_older_than_cutoff_is_persisted():
         "timestamp": stale_ts.isoformat(),
         "spot": 100.0,
         "zero_gamma": 0.1,
-        "net_gex": 50,
+        "sum_gex_vol": 50,
         "major_pos_vol": 10,
         "major_neg_vol": -5,
         "major_pos_oi": 1,
@@ -213,7 +213,7 @@ async def test_stale_snapshot_still_persists():
         "timestamp": latest_ts.isoformat(),
         "spot": 100.0,
         "zero_gamma": 0.1,
-        "net_gex": 50,
+        "sum_gex_vol": 50,
         "major_pos_vol": 10,
         "major_neg_vol": -5,
         "major_pos_oi": 1,
@@ -229,8 +229,8 @@ async def test_stale_snapshot_still_persists():
     await poller._record_timeseries(stale_snapshot)
     await poller.wait_for_pending_timeseries_writes()
 
-    net_gex_samples = [rec for rec in ts.samples if ":net_gex:" in rec[0]]
-    assert len(net_gex_samples) == 2
+    sum_gex_vol_samples = [rec for rec in ts.samples if ":sum_gex_vol:" in rec[0]]
+    assert len(sum_gex_vol_samples) == 2
     assert poller.snapshot_count == 2
     assert len(fake_writer.snapshots) == 2
 
@@ -248,8 +248,6 @@ def test_combine_payloads_normalizes_numeric_strings():
             "timestamp": 1700000000,
             "spot": "100.5",
             "zero_gamma": "101.5",
-            "net_gex": "2500000",
-            "net_gex_oi": "1250000",
             "sum_gex_vol": "2500000",
             "sum_gex_oi": "1250000",
             "major_pos_vol": "1200000",
@@ -264,7 +262,7 @@ def test_combine_payloads_normalizes_numeric_strings():
 
     assert snapshot["spot"] == 100.5
     assert snapshot["zero_gamma"] == 101.5
-    assert snapshot["net_gex"] == 2500000.0
+    assert snapshot["sum_gex_vol"] == 2500000.0
     assert snapshot["delta_risk_reversal"] == -0.75
     assert snapshot["major_pos_vol"] == 1200000.0
     assert snapshot["major_neg_vol"] == -900000.0
@@ -285,7 +283,7 @@ async def test_snapshot_cache_writes_even_if_timeseries_fails():
         "timestamp": datetime.utcnow().replace(tzinfo=timezone.utc).isoformat(),
         "spot": 100.0,
         "zero_gamma": 0.1,
-        "net_gex": 50,
+        "sum_gex_vol": 50,
         "major_pos_vol": 10,
         "major_neg_vol": -5,
         "major_pos_oi": 1,
@@ -300,7 +298,7 @@ async def test_snapshot_cache_writes_even_if_timeseries_fails():
 
     cached = json.loads(fake_redis.get("gex:snapshot:NQ_NDX"))
     assert cached["symbol"] == "NQ_NDX"
-    assert cached["net_gex"] == 50
+    assert cached["sum_gex_vol"] == 50
     assert poller.snapshot_count == 1
     assert len(fake_writer.snapshots) == 1
     assert fake_writer.snapshots[0]["symbol"] == "NQ_NDX"


### PR DESCRIPTION
What changed

- Removed legacy `net_gex` / `net_gex_oi` exposure fields from the GEX live path and Discord formatting path.
- Canonicalized on `sum_gex_vol` and `sum_gex_oi` for poller output, RedisTimeSeries, websocket snapshots, and bot rendering.
- Updated poller and snapshot tests to assert on the canonical fields.

Why

- The user-facing GEX schema was still surfacing legacy aliases, which caused inconsistent output and confusion around the source of truth.

Validation

- `ruff check`
- `python3 -m py_compile discord-bot/bot/trade_bot.py data-pipeline.py src/services/gexbot_poller.py src/services/tests/test_gexbot_snapshot_timestamps.py src/services/gex_duckdb_writer.py`
- Unit tests: `169 passed`
